### PR TITLE
fix: add .releaserc.json to deploy workflow path triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - 'pom.xml'
       - 'Dockerfile'
       - '.github/workflows/deploy.yml'
+      - '.releaserc.json'
 
 concurrency:
   group: deploy-petclinic-staging-service-mumford


### PR DESCRIPTION
## Summary

- Adds `.releaserc.json` to the deploy workflow path filter so changes to the semantic-release config trigger a deployment

## Why

The previous PR (#48) changed `.releaserc.json` but the deploy workflow never fired because `.releaserc.json` wasn't in the watched paths list.

## Test plan

- [ ] Merge this PR
- [ ] Verify the deploy workflow triggers
- [ ] Verify semantic release runs without the `Not Found` error and creates a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to ensure builds are triggered when release configuration files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->