### PR TITLE
ci: publish Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ permissions:
   id-token: write
   issues: write
   pull-requests: write
+  packages: write
 
 jobs:
   deploy:
@@ -52,6 +53,9 @@ jobs:
             @semantic-release/release-notes-generator
             @semantic-release/github
 
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - uses: aws-actions/configure-aws-credentials@v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -82,11 +86,14 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ steps.version.outputs.version }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}
         run: |
           docker buildx build \
             --platform linux/amd64 \
             -t $ECR_REGISTRY/petclinic-staging-repo-mumford:$IMAGE_TAG \
             -t $ECR_REGISTRY/petclinic-staging-repo-mumford:latest \
+            -t $GHCR_IMAGE:$IMAGE_TAG \
+            -t $GHCR_IMAGE:latest \
             --push \
             .
 


### PR DESCRIPTION
## Summary

- Adds `packages: write` permission to the deploy workflow
- Logs in to GHCR (`ghcr.io`) using `GITHUB_TOKEN` before the build step
- Tags and pushes the Docker image to `ghcr.io/liatrio-forge/emerald-grove-pet-clinic-jack-mumford` with both the versioned tag and `latest`
- ECR push is unchanged — ECS still deploys from ECR

After merging, each deploy will publish the image as a GitHub Package visible under the repo's **Packages** tab.

## Test plan

- [ ] Merge PR and verify deploy workflow completes successfully
- [ ] Check repo **Packages** tab for `emerald-grove-pet-clinic-jack-mumford` container image
- [ ] Confirm both `latest` and versioned tags (`sha-*` or `v*`) appear in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to support publishing container images to GitHub Container Registry in addition to existing container registry infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->